### PR TITLE
payment gateways

### DIFF
--- a/app/Events/PaymentStatusChanged.php
+++ b/app/Events/PaymentStatusChanged.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentStatusChanged
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $payment;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($payment)
+    {
+        $this->payment = $payment;
+    }
+}

--- a/app/Listeners/SendGatewayCallback.php
+++ b/app/Listeners/SendGatewayCallback.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\PaymentStatusChanged;
+use App\Models\Payment;
+use App\Services\Payment\PaymentGatewayOneService;
+use App\Services\Payment\PaymentGatewayTwoService;
+
+class SendGatewayCallback
+{
+    /**
+     * Handle the event.
+     * What gateway pay going?
+     *
+     * @return void
+     */
+    public function handle(PaymentStatusChanged $event)
+    {
+        $payment = $event->payment;
+        $service = null;
+
+        switch ($payment->gateway_id) {
+            case 1: {
+                $service = new PaymentGatewayOneService();
+            }
+            case 2: {
+                $service = new PaymentGatewayTwoService();
+            }
+
+            $service?->sendCallback($payment);
+        }
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Events\PaymentStatusChanged;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'status',
+    ];
+
+    /**
+     * The event map for the model.
+     *
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'updated' => PaymentStatusChanged::class,
+    ];
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Events\PaymentStatusChanged;
+use App\Listeners\SendGatewayCallback;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -17,6 +19,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        PaymentStatusChanged::class => [
+            SendGatewayCallback::class
         ],
     ];
 

--- a/app/Services/Payment/AbstractPaymentGatewayService.php
+++ b/app/Services/Payment/AbstractPaymentGatewayService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services\Payment;
+
+use App\Models\Payment;
+use Illuminate\Support\Carbon;
+
+abstract class AbstractPaymentGatewayService
+{
+
+    protected $limit;
+    protected $headers = [];
+    protected \GuzzleHttp\Client $client;
+
+    function __construct()
+    {
+        $this->client = new \GuzzleHttp\Client();
+    }
+
+    /**
+     * send callback to payment gateway
+     */
+    abstract function sendCallback(Payment $payment);
+
+    /**
+     * generate sign
+     */
+    abstract function makeSign($payload): string;
+
+    /**
+     * check daily payment limit
+     *
+     * @param Payment $payment
+     * @param int $newAmount
+     * @param string $completedStatus
+     * @param int $gatewayId
+     * @return bool
+     */
+    protected function checkLimit(Payment $payment, int $newAmount, string $completedStatus, int $gatewayId): bool
+    {
+        $sumAmount = Payment::where([
+            ['user_id', $payment->user_id],
+            ['gateway_id', $gatewayId],
+            ['status', $completedStatus],
+            ['created_at', '>=', Carbon::yesterday()->format('Y-m-d H:i:s')]
+        ])->get('amount')->sum('amount');
+
+        return $sumAmount + $newAmount <= $this->limit;
+    }
+
+    /**
+     * Check if payment status was changed on progress
+     *
+     * @param Payment $payment
+     * @param string $status
+     * @return bool
+     */
+    protected function checkStatus(Payment $payment, string $status): bool
+    {
+        return $payment->status == $status;
+    }
+}

--- a/app/Services/Payment/PaymentGatewayOneService.php
+++ b/app/Services/Payment/PaymentGatewayOneService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services\Payment;
+
+use App\Models\Payment;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Hash;
+
+class PaymentGatewayOneService extends AbstractPaymentGatewayService
+{
+    protected $merchant_id = '6';
+    protected $merchant_key = 'KaTf5tZYHx4v7pgZ';
+    protected $callback_url = 'callback_url';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->headers = ['Content-Type' => 'application/json'];
+        $this->limit = '100';
+    }
+
+    /**
+     * @param $payment
+     * @return void
+     */
+    public function sendCallback($payment)
+    {
+        if (!$this->checkStatus($payment, 'pending')) {
+            return;
+        }
+
+        if (!$this->checkLimit($payment, $payment->amount, 'paid', 1)) {
+            return;
+        }
+
+        try {
+            $payload = [
+                'merchant_id' => $this->merchant_id,
+                'payment_id' => $payment->id,
+                'status' => $payment->status,
+                'amount' => $payment->amount,
+                'amount_paid' => $payment->amount,
+                'timestamp' => $payment->updated_at,
+            ];
+
+            $sign = $this->makeSign($payload);
+            $payload['sign'] = $sign;
+
+            $response = $this->client->post($this->callback_url, [
+                'query' => $payload,
+                'headers' => $this->headers,
+            ]);
+
+        } catch (GuzzleException $e) {
+            //TODO: make return $e->getMessage();
+            return;
+        }
+
+        //TODO: make return $response->getBody();
+        return;
+    }
+
+    /**
+     * @param $payload
+     * @return string
+     */
+    public function makeSign($payload): string
+    {
+        unset($payload['sign']);
+
+        $sign = implode(':', $payload);
+        $sign .= $this->merchant_key;
+        return Hash::make($sign);
+    }
+}

--- a/app/Services/Payment/PaymentGatewayTwoService.php
+++ b/app/Services/Payment/PaymentGatewayTwoService.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services\Payment;
+
+use App\Models\Payment;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class PaymentGatewayTwoService extends AbstractPaymentGatewayService
+{
+
+    protected $app_id = '816';
+    protected $app_key = 'rTaasVHeteGbhwBx';
+    protected $callback_url = 'callback_url';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->limit = '1000';
+    }
+
+    /**
+     * @param Payment $payment
+     * @return void
+     */
+    public function sendCallback(Payment $payment)
+    {
+        if (!$this->checkStatus($payment, 'inprogress')) {
+            return;
+        }
+        if (!$this->checkLimit($payment, $payment->amount, 'completed', 2)) {
+            return;
+        }
+
+        try {
+            $payload = [
+                'project' => 816,
+                'invoice' => 73,
+                'status' => 'completed',
+                'amount' => $payment->amount,
+                'amount_paid' => $payment->amount,
+                'rand' => Str::random(8),
+            ];
+
+            $this->headers = [
+                'Authorization' => $this->makeSign($payload),
+                'Content-Type' => 'multipart/form-data'
+            ];
+
+            $response = $this->client->post($this->callback_url, [
+                'query' => $payload,
+                'headers' => $this->headers,
+            ]);
+
+        } catch (GuzzleException $e) {
+            //TODO: make return $e->getMessage();
+            return;
+        }
+
+        //TODO: make return $response->getBody();
+        return;
+    }
+
+    /**
+     * @param $payload
+     * @return string
+     */
+    public function makeSign($payload): string
+    {
+        $sign = implode('..', $payload);
+        $sign .= $this->app_key;
+
+        return md5($sign);
+    }
+
+}

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Payment>
+ */
+class PaymentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => fake()->numberBetween(1,3),
+            'status' => fake()->randomElement(['inprogress', 'paid', 'expired', 'rejected', 'new', 'pending', 'completed']),
+            'amount' => mt_rand(50, 100),
+            'gateway_id' => fake()->numberBetween(1,2),
+        ];
+    }
+}

--- a/database/migrations/2022_09_06_025548_create_payments_table.php
+++ b/database/migrations/2022_09_06_025548_create_payments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->integer('user_id');
+            $table->string('status');
+            $table->integer('amount');
+            $table->Integer('gateway_id');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,7 +14,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+         \App\Models\User::factory(3)->create();
+        \App\Models\Payment::factory(15)->create();
 
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',


### PR DESCRIPTION
Для развёртки (если совесем прям надо) запустить миграции и сид. 

Бизнес логика: 

При изменении (update) модели Payment срабатывает слушатель отравляющий данные на колбек сервисы.
внутри слушателя смотрим id gateway (не лучшая идея смотреть id но ради примера пойдёт) направляем на нужный обработчик. 

Обработчиком выступает сервис реализованный от абстрактного. 
Можно задать свои параметры limit callback url итд внутри каждого gateway. 

Перед отправкой смотрим лимиты и статус. 
Статус должен быть в обработке иначе какой смысл отправлять платёж. 

Обработки результатов и ошибок нет но и не надо по задаче делать поэтому там todo.

p.s события масс апдейта fill работает